### PR TITLE
IOS-8413: [Tech] Use prebuilt `swift-protobuf-binaries` dependency (FB 10.29.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,8 +148,8 @@ let package = Package(
       "2.1.0" ..< "3.0.0"
     ),
     .package(
-      url: "https://github.com/apple/swift-protobuf.git",
-      "1.19.0" ..< "2.0.0"
+      url: "https://github.com/tangem/swift-protobuf-binaries.git",
+      .upToNextMajor(from: "1.25.2-tangem1")
     ),
     googleAppMeasurementDependency(),
     .package(
@@ -850,7 +850,7 @@ let package = Package(
         "FirebaseInstallations",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULUserDefaults", package: "GoogleUtilities"),
-        .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+        .product(name: "SwiftProtobuf", package: "swift-protobuf-binaries"),
       ],
       path: "FirebaseMLModelDownloader/Sources",
       exclude: [


### PR DESCRIPTION
В SDK есть одна зависимость (btw мы ее не юзаем) `FirebaseMLModelDownloader`, которая зависит от `SwiftProtobuf`:
```
.package(
  url: "https://github.com/apple/swift-protobuf.git",
  "1.19.0" ..< "2.0.0"
),
```

Поэтому пришлось сделать правку, чтобы юзались бинарники протобафа

---

Для обновления на новые версии FB я предлагаю такую схему:
1. Синкаем апстрим кнопкой в gh
2. Выбираем версию, на которую хотим обновить FB - например последнюю на сегодня `11.6.0`
3. Отводим от этого тега ветку вида `release-11.6.0` (для некоторых релизов такие ветки уже есть, видимо в апстриме делались какие-то правки)
4. В `release-11.6.0` делаем пулл из фича-ветки, в которую пикнут один единственный коммит `5faa3aec04c2dda27c1e33196a9559a2ecdd4659` (с правкой для `SwiftProtobuf`)
5. После мерджа фича-ветки в `release-11.6.0` вешаем на коммит мержа тег `11.6.0-tangem1`, на который будет смотреть приложение

Таким образом будут исключены конфликты при подливании апстрима